### PR TITLE
Refactor plugin config for lolcommits v0.10.0

### DIFF
--- a/lib/lolcommits/plugin/term_output.rb
+++ b/lib/lolcommits/plugin/term_output.rb
@@ -6,15 +6,6 @@ module Lolcommits
     class TermOutput < Base
 
       ##
-      # Returns the name of the plugin to identify it to lolcommits.
-      #
-      # @return [String] the plugin name
-      #
-      def self.name
-        'term_output'
-      end
-
-      ##
       # Returns position(s) of when this plugin should run during the capture
       # process. The image is presented to the terminal when the capture is
       # ready.
@@ -35,7 +26,7 @@ module Lolcommits
         if terminal_supported?
           super
         else
-          puts "Sorry, this terminal does not support the #{self.class.name} plugin (requires iTerm2)"
+          puts "Sorry, this terminal does not support this plugin (requires iTerm2)"
           {}
         end
       end

--- a/lib/lolcommits/term_output/version.rb
+++ b/lib/lolcommits/term_output/version.rb
@@ -1,5 +1,5 @@
 module Lolcommits
   module TermOutput
-    VERSION = "0.0.4".freeze
+    VERSION = "0.0.5".freeze
   end
 end

--- a/lolcommits-term_output.gemspec
+++ b/lolcommits-term_output.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.0.0"
 
-  spec.add_development_dependency "lolcommits", ">= 0.9.8"
+  spec.add_development_dependency "lolcommits", ">= 0.10.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"

--- a/test/lolcommits/plugin/term_output_test.rb
+++ b/test/lolcommits/plugin/term_output_test.rb
@@ -18,14 +18,6 @@ describe Lolcommits::Plugin::TermOutput do
     ENV['TMUX'] = @old_tmux
   end
 
-  def plugin_name
-    "term_output"
-  end
-
-  it "should have a name" do
-    ::Lolcommits::Plugin::TermOutput.name.must_equal plugin_name
-  end
-
   it "should run on capture ready" do
     ::Lolcommits::Plugin::TermOutput.runner_order.must_equal [:capture_ready]
   end
@@ -34,11 +26,7 @@ describe Lolcommits::Plugin::TermOutput do
     def runner
       # a simple lolcommits runner with an empty configuration Hash
       @runner ||= Lolcommits::Runner.new(
-        main_image: Tempfile.new('main_image.jpg'),
-        config: OpenStruct.new(
-          read_configuration: {},
-          loldir: File.expand_path("#{__dir__}../../../images")
-        )
+        main_image: Tempfile.new('main_image.jpg')
       )
     end
 
@@ -47,18 +35,16 @@ describe Lolcommits::Plugin::TermOutput do
     end
 
     def valid_enabled_config
-      @config ||= OpenStruct.new(
-        read_configuration: { plugin_name => { "enabled" => true } }
-      )
+      { enabled: true }
     end
 
     describe "#enabled?" do
       it "is false by default" do
-        plugin.enabled?.must_equal false
+        assert_nil plugin.enabled?
       end
 
       it "is true when configured" do
-        plugin.config = valid_enabled_config
+        plugin.configuration = valid_enabled_config
         plugin.enabled?.must_equal true
       end
     end
@@ -69,7 +55,7 @@ describe Lolcommits::Plugin::TermOutput do
 
       def check_plugin_output(matching_regex)
         in_repo do
-          plugin.config = valid_enabled_config
+          plugin.configuration = valid_enabled_config
           output = fake_io_capture { plugin.run_capture_ready }
           output.must_match matching_regex
         end
@@ -109,7 +95,7 @@ describe Lolcommits::Plugin::TermOutput do
           configured_plugin_options = plugin.configure_options!
         end
 
-        configured_plugin_options.must_equal({ "enabled" => true })
+        configured_plugin_options.must_equal({ enabled: true })
       end
 
       describe "when terminal not supported" do
@@ -126,7 +112,7 @@ describe Lolcommits::Plugin::TermOutput do
           end
 
           assert_equal configured_plugin_options, {}
-          output.must_match(/Sorry, this terminal does not support the term_output plugin/)
+          output.must_match(/Sorry, this terminal does not support this plugin/)
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-# necessary libs from lolcommits (allowing plugin to run)
-require 'git'
-require 'lolcommits/runner'
-require 'lolcommits/vcs_info'
-require 'lolcommits/backends/git_info'
+# lolcommits gem
+require 'lolcommits'
 
 # lolcommit test helpers
 require 'lolcommits/test_helpers/git_repo'


### PR DESCRIPTION
* require at least lolcommits >= 0.10.0
* drop`self.name` method (plugins are now identified by their gem name)
* drop calls to `configured?` (no longer available or useful)
* symbolize all plugin config keys
* bump gem version (for new plugin release)